### PR TITLE
SymInitialize: Invade the process is not necessary

### DIFF
--- a/src/DbgSymGrabber/DbgSymGrabber.cpp
+++ b/src/DbgSymGrabber/DbgSymGrabber.cpp
@@ -197,7 +197,7 @@ void OnInitDialog( __in HWND hwnd )
 		return;
 	}
 
-	g_bReady = fpSymInitializeW(GetCurrentProcess(), NULL, TRUE);
+	g_bReady = fpSymInitializeW(GetCurrentProcess(), NULL, FALSE);
  	if (g_bReady)
  	{
 		fpSymSetParentWindow(hwnd);


### PR DESCRIPTION
Set the `fInvadeProcess` parameter to FALSE, otherwise the program may take too long time to load all module's symbol (which isn't actually needed) before the window can be displayed.